### PR TITLE
Add apigw execution ARN (non stage) to outputs - used by Lambda invok…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "aws_api_gateway_rest_api_id" {
   description = "REST API id of the created api"
 }
 
+output "aws_api_gateway_execution_arn" {
+  value       = aws_api_gateway_rest_api.api.execution_arn
+  description = "The execution ARN part to be used in lambda_permission source_arn when allowing API Gateway to invoke a Lambda function"
+}
+
 output "aws_api_gateway_stage_name" {
   value       = aws_api_gateway_stage.stage.stage_name
   description = "Stage name of the deployed api gateway stage"


### PR DESCRIPTION
When creating permissions for lambda invocation, we need to use the REST API's execution ARN and not the stage ARN (one level broader). This PR adds the REST API's exec ARN to outputs for ease of use by the module user.