### PR TITLE
Auto update stage vars with VPC Link ID's

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,5 @@ API gateway module for REST API. There is no community module available for REST
 | <a name="output_aws_api_gateway_stage_execution_arn"></a> [aws\_api\_gateway\_stage\_execution\_arn](#output\_aws\_api\_gateway\_stage\_execution\_arn) | The execution ARN part to be used in lambda\_permission source\_arn when allowing API Gateway to invoke a Lambda function |
 | <a name="output_aws_api_gateway_stage_invoke_url"></a> [aws\_api\_gateway\_stage\_invoke\_url](#output\_aws\_api\_gateway\_stage\_invoke\_url) | The URL to invoke the API pointing to the stage |
 | <a name="output_aws_api_gateway_stage_name"></a> [aws\_api\_gateway\_stage\_name](#output\_aws\_api\_gateway\_stage\_name) | Stage name of the deployed api gateway stage |
+| <a name="output_aws_api_gateway_vpc_link_id"></a> [aws\_api\_gateway\_vpc\_link\_id](#output\_aws\_api\_gateway\_vpc\_link\_id) | VPC Link ID that can be used in API Gateway integrations with VPC Link |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "aws_api_gateway_stage" "stage" {
   rest_api_id   = aws_api_gateway_rest_api.api.id
 
   stage_name            = var.stage
-  variables             = var.stage_variables
+  variables             = length(var.vpc_links) > 0 ? merge({ for k, v in values(aws_api_gateway_vpc_link.vpc_link)[*] : v.name => v.id }, var.stage_variables) : var.stage_variables
   xray_tracing_enabled  = true
   cache_cluster_enabled = var.cache_cluster_enabled
   cache_cluster_size    = var.cache_cluster_size

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ resource "aws_api_gateway_stage" "stage" {
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {
+  #checkov:skip=CKV_AWS_338: Ensure CloudWatch log groups retains logs for at least 1 year
   #checkov:skip=CKV_AWS_158: Using default key in KMS instead of CMK
   #Custom name if it is imported
   name              = var.log_group_name != "" ? var.log_group_name : "${var.name}-access-logs"

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "aws_api_gateway_stage_invoke_url" {
   value       = aws_api_gateway_stage.stage.invoke_url
   description = "The URL to invoke the API pointing to the stage"
 }
+
+output "aws_api_gateway_vpc_link_id" {
+  value       = { for k, v in values(aws_api_gateway_vpc_link.vpc_link)[*] : v.name => v.id }
+  description = "VPC link id"
+}


### PR DESCRIPTION
Update Stage Variables with VPC Link ID's, so it can be referred while importing from swagger or open API 3.