### PR TITLE
added outputs to allow creation of route53 alias

### DIFF
--- a/modules/custom_domain/README.md
+++ b/modules/custom_domain/README.md
@@ -18,7 +18,7 @@ Provisions option to create ACM certifcation. Cert validation needs to be done o
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 
@@ -49,4 +49,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of domain name. |
+| <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | hostname for custom domain regional/cloudfront endpoint |
+| <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | hosted zone id of custom domain |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/custom_domain/outputs.tf
+++ b/modules/custom_domain/outputs.tf
@@ -2,3 +2,13 @@ output "arn" {
   value       = var.endpoint_type == "EDGE" ? aws_api_gateway_domain_name.domain_edge[0].arn : aws_api_gateway_domain_name.domain_regional[0].arn
   description = "ARN of domain name."
 }
+
+output "domain_name" {
+  value       = var.endpoint_type == "EDGE" ? aws_api_gateway_domain_name.domain_edge[0].cloudfront_domain_name : aws_api_gateway_domain_name.domain_regional[0].regional_domain_name
+  description = "hostname for custom domain regional/cloudfront endpoint"
+}
+
+output "hosted_zone_id" {
+  value       = var.endpoint_type == "EDGE" ? aws_api_gateway_domain_name.domain_edge[0].cloudfront_zone_id : aws_api_gateway_domain_name.domain_regional[0].regional_zone_id
+  description = "hosted zone id of custom domain"
+}


### PR DESCRIPTION
added `hosted_zone_id` and `domain_name` to allow using custom domain to create route 53 alias for API Gateway custom  domain