### PR TITLE
add key algorithm for acm certificate, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ API gateway module for REST API. There is no community module available for REST
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 

--- a/modules/custom_domain/README.md
+++ b/modules/custom_domain/README.md
@@ -12,7 +12,7 @@ Provisions option to create ACM certifcation. Cert validation needs to be done o
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67.0 |
 
 ## Providers
 
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_create_acm_cert"></a> [create\_acm\_cert](#input\_create\_acm\_cert) | Create ACM cert. create\_acm\_cert and cert\_arn Mutually exclusive. | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Custom domain name | `string` | n/a | yes |
 | <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | Endpoint type. | `string` | `"REGIONAL"` | no |
+| <a name="input_key_algorithm"></a> [key\_algorithm](#input\_key\_algorithm) | Key algorithm for the cert | `string` | `"EC_prime256v1"` | no |
 | <a name="input_path_mappings"></a> [path\_mappings](#input\_path\_mappings) | List of stages the usage plan can be used | <pre>map(<br>    object({<br>      api_id     = string<br>      stage_name = string<br>      base_path  = string<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_security_policy"></a> [security\_policy](#input\_security\_policy) | TLS Security Policy for the domain | `string` | `"TLS_1_2"` | no |
 

--- a/modules/custom_domain/main.tf
+++ b/modules/custom_domain/main.tf
@@ -40,6 +40,7 @@ resource "aws_acm_certificate" "cert" {
 
   domain_name       = var.domain_name
   validation_method = "DNS"
+  key_algorithm     = var.key_algorithm
 
   lifecycle {
     create_before_destroy = true

--- a/modules/custom_domain/variables.tf
+++ b/modules/custom_domain/variables.tf
@@ -25,6 +25,12 @@ variable "cert_arn" {
   default     = ""
 }
 
+variable "key_algorithm" {
+  description = "Key algorithm for the cert"
+  type        = string
+  default     = "EC_prime256v1"
+}
+
 variable "path_mappings" {
   description = "List of stages the usage plan can be used "
   type = map(

--- a/modules/usage_plan/README.md
+++ b/modules/usage_plan/README.md
@@ -8,13 +8,13 @@ Create Usage Plan and assign it to the API
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.67.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 


### PR DESCRIPTION
SCP requires the `key_algorithm` key to be specified or else `terraform apply` will fail. Updated the documentation to reflect new variable.