### PR TITLE
change custom domain acm creation condition

### DIFF
--- a/modules/custom_domain/main.tf
+++ b/modules/custom_domain/main.tf
@@ -36,7 +36,7 @@ resource "aws_api_gateway_base_path_mapping" "mapping" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  count = var.create_acm_cert && var.cert_arn == "" ? 1 : 0
+  count = var.create_acm_cert ? 1 : 0
 
   domain_name       = var.domain_name
   validation_method = "DNS"


### PR DESCRIPTION
The current condition when starting from an empty environment will always throw an error:

```
Error: Invalid count argument
on .terraform/modules/apigw.apigw_custom_domain/modules/custom_domain/main.tf line 39, in resource "aws_acm_certificate" "cert":
  count = var.create_acm_cert && var.cert_arn == "" ? 1 : 0
The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on
```

To fix this, fix the condition to only check for `var.create_acm_cert` and set it to `true` if required