### PR TITLE
add support for terraform resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_api_gateway_deployment" "deployment" {
 
   triggers = {
     redeployment = sha1(jsonencode([
+      var.tf_resources_hash,
       aws_api_gateway_rest_api.api.body,
       var.enable_resource_policy ? var.resource_policy_json : null
       ]

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "tf_resources_hash" {
+  description = "for api gateways that are not using body_template and are using terraform resources"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- adds support for terraform resources/not using body_template to define APIs

The hash will be computed beforehand and passed into the variable that is added to trigger new deployments whenever there is a change on the endpoints.

Reference:
```
resource "aws_api_gateway_deployment" "example" {
  rest_api_id = aws_api_gateway_rest_api.example.id

  triggers = {
    # NOTE: The configuration below will satisfy ordering considerations,
    #       but not pick up all future REST API changes. More advanced patterns
    #       are possible, such as using the filesha1() function against the
    #       Terraform configuration file(s) or removing the .id references to
    #       calculate a hash against whole resources. Be aware that using whole
    #       resources will show a difference after the initial implementation.
    #       It will stabilize to only change when resources change afterwards.
    redeployment = sha1(jsonencode([
      aws_api_gateway_resource.example.id,
      aws_api_gateway_method.example.id,
      aws_api_gateway_integration.example.id,
    ]))
  }

  lifecycle {
    create_before_destroy = true
  }
}
```