### PR TITLE
CAAS-1129: Allow additional tags to be added to api keys

### DIFF
--- a/modules/usage_plan/main.tf
+++ b/modules/usage_plan/main.tf
@@ -41,10 +41,10 @@ resource "aws_api_gateway_api_key" "key" {
   description = "API Key for ${each.value.key_name}"
   enabled     = each.value.enabled
 
-  tags = {
-    Name = each.value.key_name
-  }
-
+  tags = merge(
+    { Name = each.value.key_name },
+    try(each.value.extra_tags, {})
+  )
 }
 
 resource "aws_api_gateway_usage_plan_key" "main" {


### PR DESCRIPTION
Allow users to define additional tags for the API keys they generate

CaaS can use `extra_tags` to define additional tags like the full name of the publication (This is different from the `Name` tag that already exists. We need a separate tag for a feature we're building)

**Jira Ticket:**
https://sph.atlassian.net/jira/software/c/projects/CAAS/boards/939?selectedIssue=CAAS-1129